### PR TITLE
Changing columns from width-4 to width-6

### DIFF
--- a/pages/resources/protocols.md
+++ b/pages/resources/protocols.md
@@ -21,7 +21,7 @@ Current protocols.
     </div>
     {% for page in site.html_pages %}
     {% if page.folder == "protocols" %}
-    <div class="col-md-4">
+    <div class="col-md-6">
         <div class="media">
             <div class="pull-left">
                     <span class="fa-stack fa-2x">

--- a/pages/resources/resources.html
+++ b/pages/resources/resources.html
@@ -14,7 +14,7 @@ tags: [resources]
     </div>
     {% for page in site.html_pages %}
     {% if page.folder == "viruses" %}
-    <div class="col-md-4">
+    <div class="col-md-6">
         <div class="media">
             <div class="pull-left">
                     <span class="fa-stack fa-2x">
@@ -38,7 +38,7 @@ tags: [resources]
     </div>
     {% for page in site.html_pages %}
     {% if page.folder == "protocols" %}
-    <div class="col-md-4">
+    <div class="col-md-6">
         <div class="media">
             <div class="pull-left">
                     <span class="fa-stack fa-2x">
@@ -62,7 +62,7 @@ tags: [resources]
     </div>
     {% for page in site.html_pages %}
     {% if page.folder == "software" %}
-    <div class="col-md-4">
+    <div class="col-md-6">
         <div class="media">
             <div class="pull-left">
                     <span class="fa-stack fa-2x">
@@ -81,4 +81,4 @@ tags: [resources]
 </div>
 
 
-{% include links.html %}
+<!-- {% include links.html %} -->

--- a/pages/resources/software.md
+++ b/pages/resources/software.md
@@ -21,7 +21,7 @@ Current viruses.
     </div>
     {% for page in site.html_pages %}
     {% if page.folder == "software" %}
-    <div class="col-md-4">
+    <div class="col-md-6">
         <div class="media">
             <div class="pull-left">
                     <span class="fa-stack fa-2x">

--- a/pages/resources/viruses.md
+++ b/pages/resources/viruses.md
@@ -22,7 +22,7 @@ Current viruses.
     </div>
     {% for page in site.html_pages %}
     {% if page.folder == "viruses" %}
-    <div class="col-md-4">
+    <div class="col-md-6">
         <div class="media">
             <div class="pull-left">
                     <span class="fa-stack fa-2x">


### PR DESCRIPTION
- Given the number of items in each section, I think width-6 (two items per row) looks nicer than width-4 (three items per row) layout-wise.
- Also hides broken links.html section on the resources page.