### PR TITLE
Renamed show/hide navbar button

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -16,7 +16,7 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-center">
                 <!-- toggle sidebar button -->
-                <li><a id="tg-sb-link" href="#"><i id="tg-sb-icon" class="fa fa-toggle-on"></i> Nav</a></li>
+                <li><a id="tg-sb-link" href="#"><i id="tg-sb-icon" class="fa fa-toggle-on"></i> Toggle Sidebar</a></li>
                 <!-- entries without drop-downs appear here -->
             </ul>
             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Renamed the show/hide navbar button from 'Nav' to 'Toggle Sidebar', as IMO this is clearer. 