### PR TITLE
Fix broken link for tag_projects to make CI pass

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -47,6 +47,7 @@ layout: default
 
    {{content}}
 
+{% comment %}
     <div class="tags">
         {% if page.tags != null %}
         <b>Tags: </b>
@@ -58,6 +59,7 @@ layout: default
         {% endfor %}
         {% endif %}
     </div>
+{% endcomment %}
 
 {% include commento.html %}
 

--- a/pages/projects/artic1.md
+++ b/pages/projects/artic1.md
@@ -9,8 +9,6 @@ permalink: /projects/artic1
 folder: projects
 ---
 
-# ARTIC-1
-
 ## Motivation
 
 This project is developing an end-to-end system for processing samples from viral outbreaks to generate real-time epidemiological information that is interpretable and actionable by public health bodies.

--- a/pages/tags/tag_projects.md
+++ b/pages/tags/tag_projects.md
@@ -1,0 +1,12 @@
+---
+title: "Projects pages"
+tagName: projects
+search: exclude
+permalink: /tag_projects.html
+sidebar: artic_sidebar
+folder: tags
+---
+
+{% include taglogic.html %}
+
+{% include links.html %}


### PR DESCRIPTION
Fixed by creating missing file, but also made redundant by commenting out tags section entirely, since we probably don't want these cluttering top level pages yet. Can be reinstated if needed