### PR TITLE
Add "News" job post for ARTIC 2 position

### DIFF
--- a/_posts/2025-07-29-artic-2-open-position.md
+++ b/_posts/2025-07-29-artic-2-open-position.md
@@ -1,0 +1,33 @@
+---
+title:  "Opportunity to Join Pathoplexus, Loculus, & ARTIC 2"
+published: true
+permalink: 2025-07-29-artic-2-open-position.html
+tags: [news]
+author: Emma Hodcroft
+---
+
+Are you excited by the idea of building global infrastructure to make pathogen sequencing more accessible, interpretable, and equitable? The [Epidemiology and Virus Evolution (EVE) Group](https://www.swisstph.ch/en/about/mpi/epidemiology-and-viral-evolution) at the [Swiss Tropical and Public Health Institute](https://www.swisstph.ch/en/) (Swiss TPH) is offering a unique opportunity to work at the intersection of world-leading efforts:
+
+- [ARTIC 2](https://artic.network/) the latest evolution of the renowned ARTIC project, enabling affordable, portable, and real-time genetic sequencing & surveillance
+- [Pathoplexus](https://pathoplexus.org/) a pioneering open-source platform redefining how viral sequence data is shared and governed globally, powered by the modular backend database software [Loculus](https://loculus.org/)
+
+This is a chance to be part of an international team making a very real, tangible impact on global health and data equity!
+
+Some key aims of the position:
+- Design and deployment of privacy-conscious, locally-hosted genomic data infrastructures using Loculus
+- Extending Loculus to link seamlessly with the ARTIC 2 sequencing pipeline for local storage, as well as enabling easy ‘one-button’ upload of viral sequence data to Pathoplexus
+- Integration of viral and bacterial analytical pipelines into Cephalopod, the offline research engine of ARTIC 2
+
+We're offering 1 position in two different forms to find the perfect candidate:
+- A post-doctoral position for those on an academic track, with support for traditional academic outputs and career advancement: https://jobs.swisstph.ch/Vacancies/1087/Description/2
+- A software engineer position for those without a PhD, with support for learning about biological data & skill-building: https://jobs.swisstph.ch/Vacancies/1082/Description/2
+
+Please see the job listings above for full descriptions and requirements! 
+oth positions require a strong coding background (though more experience is expected for the software developer position). Please apply once for the position best suited to you. 
+
+For informal questions (not applications) please use applications[at]hodcroft.com
+
+This job is onsite in Basel, Switzerland - 80-100% - ideally starting this year or early 2026, fixed-term for 2 years. 
+We welcome diverse and international applicants!
+
+{% include links.html %}


### PR DESCRIPTION
Adds a new 'News' post for the ARTIC 2 Loculus/Pathoplexus software-dev/post-doc position

I was not sure whether the website needs to be built (or how), so have just added the `.md` file here - if there's instructions on how to build please let me know and can attempt :) 